### PR TITLE
docs(readme): fix typo in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,8 @@ Create a sentinel:
 
 >>> import sentinel
 >>> MySentinel = sentinel.create("MySentinel")
->>> Sentinel
-Sentinel
+>>> MySentinel
+MySentinel
 
 If you have python-varname_ installed, or installed this module using
 ``pip install 'sentinel[varname]'``, ``sentinel.create()`` can infer the name


### PR DESCRIPTION
On one of the examples, a sentinel `MySentinel` is created, but then a sentinel `Sentinel` is used.

I can't seem to figure out where that `Sentinel` came from, so I believe it's a typo, and should be `MySentinel`.